### PR TITLE
Remove Chinese copy and toggle contextual help

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -305,13 +305,10 @@ const App = () => {
         onCancel={() => setSignalsInfoVisible(false)}
         footer={null}
         width={720}
-        title="Signal Annotations / 信号说明"
+        title="Signal Annotations"
       >
         <Paragraph>
-          <strong>English:</strong> A blue line shows the average price of the securities in the filtered universe. A green triangle marks a day where the enabled indicators all agreed to open a position (a <em>buy signal</em>). A red diamond marks the automated exit for that position, generated after the specified hold days or when the stop-loss / take-profit thresholds were reached.
-        </Paragraph>
-        <Paragraph>
-          <strong>中文：</strong> 蓝色曲线表示筛选后股票池的平均价格。绿色三角形代表指标同时满足后的买入信号；红色菱形表示根据设定的持仓天数或止损/止盈阈值自动平仓的卖出信号。
+          A blue line shows the average price of the securities in the filtered universe. A green triangle marks a day where the enabled indicators all agreed to open a position (a <em>buy signal</em>). A red diamond marks the automated exit for that position, generated after the specified hold days or when the stop-loss / take-profit thresholds were reached.
         </Paragraph>
         <Paragraph>
           Buy and sell markers always appear in pairs. If you hide either layer with the toggles above, the chart keeps its time axis so you can focus on the remaining information.

--- a/frontend/src/components/SidebarForm.tsx
+++ b/frontend/src/components/SidebarForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { CSSProperties, ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import {
   Button,
   Card,
@@ -11,7 +11,6 @@ import {
   Switch,
   Typography,
   message,
-  Modal,
 } from "antd";
 import dayjs, { Dayjs } from "dayjs";
 import { api } from "../api/client";
@@ -72,10 +71,21 @@ const strategyPresets: Record<string, Record<string, unknown>> = {
   },
 };
 
+const infoPanelStyle: CSSProperties = {
+  background: "#f5f5f5",
+  padding: 12,
+  borderRadius: 6,
+  marginBottom: 12,
+};
+
 const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
   const [form] = Form.useForm();
   const [meta, setMeta] = useState<UniverseMeta>({ sectors: [], mcap_buckets: [] });
-  const [infoModal, setInfoModal] = useState<null | InfoModalKey>(null);
+  const [expandedInfo, setExpandedInfo] = useState<null | InfoModalKey>(null);
+
+  const toggleInfo = (key: InfoModalKey) => {
+    setExpandedInfo((prev) => (prev === key ? null : key));
+  };
 
   useEffect(() => {
     const fetchMeta = async () => {
@@ -275,18 +285,15 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
     await onSubmit(payload);
   };
 
-  const renderInfoContent = () => {
-    switch (infoModal) {
+  const renderInfoContent = (key: InfoModalKey): ReactNode => {
+    switch (key) {
       case "strategy":
         return (
           <>
             <Paragraph>
-              <strong>English:</strong> Strategy presets simply pre-fill indicator toggles. “Mean Reversion” focuses on RSI and EMA
-              crossovers, “Momentum” enables MACD / OBV / Stochastic, and “Multifactor” activates every indicator so you can
-              fine-tune thresholds yourself. You may adjust any setting after choosing a preset.
-            </Paragraph>
-            <Paragraph>
-              <strong>中文：</strong> 策略预设只是快速勾选指标。「均值回归」侧重 RSI 与 EMA，「动量」启用 MACD / OBV / 随机指标，「多因子」一次打开全部指标，方便自行调整阈值。
+              Strategy presets simply pre-fill indicator toggles. “Mean Reversion” focuses on RSI and EMA crossovers, “Momentum”
+              enables MACD / OBV / Stochastic, and “Multifactor” activates every indicator so you can fine-tune thresholds
+              yourself. You may adjust any setting after choosing a preset.
             </Paragraph>
           </>
         );
@@ -294,12 +301,9 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
         return (
           <>
             <Paragraph>
-              <strong>English:</strong> Hold days determine how long each trade remains open before the platform forces an exit. Stop-loss
-              and take-profit inputs apply percentage limits to every trade, while fees (basis points) deduct costs on both entry
-              and exit. Adjust these controls to mirror your real-world trading friction.
-            </Paragraph>
-            <Paragraph>
-              <strong>中文：</strong> 持仓天数规定每笔交易最长持有几天，止损/止盈按百分比限制盈亏，手续费（基点）在买入和卖出时各扣一次。通过这些参数将回测与真实交易成本对齐。
+              Hold days determine how long each trade remains open before the platform forces an exit. Stop-loss and take-profit
+              inputs apply percentage limits to every trade, while fees (basis points) deduct costs on both entry and exit.
+              Adjust these controls to mirror your real-world trading friction.
             </Paragraph>
           </>
         );
@@ -307,11 +311,8 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
         return (
           <>
             <Paragraph>
-              <strong>English:</strong> The Relative Strength Index measures average gains versus losses over the lookback window. Oversold
-              mode hunts for rebounds below the threshold, while overbought mode fades rallies above the threshold.
-            </Paragraph>
-            <Paragraph>
-              <strong>中文：</strong> RSI 通过比较一定周期内的平均涨跌幅度来衡量超买超卖。选择「超卖」时，当 RSI 低于阈值即触发买入；选择「超买」则在 RSI 高于阈值时执行逆向策略。
+              The Relative Strength Index measures average gains versus losses over the lookback window. Oversold mode hunts for
+              rebounds below the threshold, while overbought mode fades rallies above the threshold.
             </Paragraph>
           </>
         );
@@ -319,11 +320,8 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
         return (
           <>
             <Paragraph>
-              <strong>English:</strong> MACD subtracts a slow EMA from a fast EMA to highlight momentum shifts. The signal-span smooths the
-              difference; use the rule control to decide between signal-line crossovers or simply MACD &gt; 0.
-            </Paragraph>
-            <Paragraph>
-              <strong>中文：</strong> MACD 通过快慢指数均线的差值体现动量变化。信号线负责平滑曲线，可选择「信号交叉」或「MACD 大于零」作为触发条件。
+              MACD subtracts a slow EMA from a fast EMA to highlight momentum shifts. The signal-span smooths the difference; use
+              the rule control to decide between signal-line crossovers or simply MACD &gt; 0.
             </Paragraph>
           </>
         );
@@ -331,11 +329,8 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
         return (
           <>
             <Paragraph>
-              <strong>English:</strong> On-Balance Volume cumulates volume on up days and subtracts it on down days. It confirms whether
-              price trends are supported by rising participation.
-            </Paragraph>
-            <Paragraph>
-              <strong>中文：</strong> OBV 在上涨日累加成交量，在下跌日扣除成交量，用于确认趋势是否得到成交量配合。
+              On-Balance Volume cumulates volume on up days and subtracts it on down days. It confirms whether price trends are
+              supported by rising participation.
             </Paragraph>
           </>
         );
@@ -343,11 +338,8 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
         return (
           <>
             <Paragraph>
-              <strong>English:</strong> EMA Cross compares a short-term and long-term exponential moving average. When the short EMA rises
-              above the long EMA, it suggests a potential trend change.
-            </Paragraph>
-            <Paragraph>
-              <strong>中文：</strong> EMA 交叉策略利用短期与长期指数均线的交叉来识别趋势转换，短期均线向上穿越长期均线通常被视为看涨信号。
+              EMA Cross compares a short-term and long-term exponential moving average. When the short EMA rises above the long
+              EMA, it suggests a potential trend change.
             </Paragraph>
           </>
         );
@@ -355,11 +347,8 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
         return (
           <>
             <Paragraph>
-              <strong>English:</strong> Average Directional Index quantifies trend strength. Requiring ADX above a minimum value helps you
-              avoid flat markets.
-            </Paragraph>
-            <Paragraph>
-              <strong>中文：</strong> ADX 用于衡量趋势强度，设置最小值可以过滤震荡行情，避免在无趋势的环境中过度交易。
+              Average Directional Index quantifies trend strength. Requiring ADX above a minimum value helps you avoid flat
+              markets.
             </Paragraph>
           </>
         );
@@ -367,11 +356,8 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
         return (
           <>
             <Paragraph>
-              <strong>English:</strong> Aroon Up and Down track how recently highs and lows occurred. Raising the up-threshold emphasises
-              fresh highs; lowering the down-threshold highlights fading momentum.
-            </Paragraph>
-            <Paragraph>
-              <strong>中文：</strong> Aroon 指标通过计算最近的高点或低点出现的时间来衡量趋势力量。提高 Aroon Up 阈值可强调新高，降低 Aroon Down 阈值可突出下行动能的衰退。
+              Aroon Up and Down track how recently highs and lows occurred. Raising the up-threshold emphasises fresh highs;
+              lowering the down-threshold highlights fading momentum.
             </Paragraph>
           </>
         );
@@ -379,11 +365,8 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
         return (
           <>
             <Paragraph>
-              <strong>English:</strong> The stochastic oscillator compares the latest close to the range of prices observed during the
-              lookback window. Configure %K/%D spans and decide whether to act on signal-line crossovers or extreme zones.
-            </Paragraph>
-            <Paragraph>
-              <strong>中文：</strong> 随机指标将最新收盘价与设定周期内的价格区间比较，可通过 %K/%D 参数及触发模式设定交叉信号或超买/超卖区间。
+              The stochastic oscillator compares the latest close to the range of prices observed during the lookback window.
+              Configure %K/%D spans and decide whether to act on signal-line crossovers or extreme zones.
             </Paragraph>
           </>
         );
@@ -391,12 +374,9 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
         return (
           <>
             <Paragraph>
-              <strong>English:</strong> Combination policy defines how individual indicators vote together. “Any” fires when one indicator
-              is true, “All” requires unanimous agreement, and “At least k” lets you specify the minimum number of agreeing
-              indicators. The histogram horizon and hold days must never exceed the maximum horizon input.
-            </Paragraph>
-            <Paragraph>
-              <strong>中文：</strong> 信号组合策略决定多个指标如何共同触发。选择「任意」表示任一指标准备就绪即可交易，「全部」要求全部指标一致，「至少 k 个」可自定义最少同时满足的数量。直方图期限与持仓天数不得超过最大期限。
+              Combination policy defines how individual indicators vote together. “Any” fires when one indicator is true, “All”
+              requires unanimous agreement, and “At least k” lets you specify the minimum number of agreeing indicators. The
+              histogram horizon and hold days must never exceed the maximum horizon input.
             </Paragraph>
           </>
         );
@@ -448,18 +428,24 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
       >
         <Card title="Strategy" size="small" bordered={false} style={{ marginBottom: 16 }}>
           <Space style={{ marginBottom: 12 }}>
-            <Button type="link" size="small" onClick={() => setInfoModal("strategy")}>
-              Describe
+            <Button type="link" size="small" onClick={() => toggleInfo("strategy")}>
+              {expandedInfo === "strategy" ? "Hide Strategy Guide" : "Describe Strategy"}
             </Button>
-            <Button type="link" size="small" onClick={() => setInfoModal("execution")}>
-              Execution Settings
+            <Button type="link" size="small" onClick={() => toggleInfo("execution")}>
+              {expandedInfo === "execution" ? "Hide Execution Guide" : "Describe Execution"}
             </Button>
           </Space>
+          {expandedInfo === "strategy" && <div style={infoPanelStyle}>{renderInfoContent("strategy")}</div>}
+          {expandedInfo === "execution" && <div style={infoPanelStyle}>{renderInfoContent("execution")}</div>}
           <Form.Item
             name="strategy"
             label="Strategy"
             rules={[{ required: true }]}
-            extra="English: Choose a preset to pre-fill indicator switches. 中文：选择预设快速启用常用指标，随后仍可手动调整。"
+            extra={
+              expandedInfo === "strategy"
+                ? "Choose a preset to pre-fill indicator switches."
+                : undefined
+            }
           >
             <Select
               onChange={handleStrategyChange}
@@ -474,14 +460,20 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
             name="date"
             label="Backtest Range"
             rules={[{ required: true }]}
-            extra="English: Pick dates between 2020-01-01 and today; the span may not exceed five calendar years. 中文：请选择 2020 年以后的日期，最长跨度为最近五年。"
+            extra={
+              expandedInfo === "strategy"
+                ? "Pick dates between 2020-01-01 and today; the span may not exceed five calendar years."
+                : undefined
+            }
           >
             <RangePicker allowClear={false} style={{ width: "100%" }} disabledDate={disabledDate} />
           </Form.Item>
           <Form.Item
             label="Initial Capital"
             name="capital"
-            extra="English: Starting portfolio value in US dollars. 中文：回测初始资金（美元），用于缩放净值曲线。"
+            extra={
+              expandedInfo === "execution" ? "Starting portfolio value in US dollars." : undefined
+            }
           >
             <InputNumber min={0} style={{ width: "100%" }} prefix="$" />
           </Form.Item>
@@ -490,7 +482,11 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
               label="Fee (bps)"
               name="fee_bps"
               style={{ flex: 1 }}
-              extra="English: Basis points charged on both entry and exit (10 bps = 0.10%). 中文：买入和卖出都扣除的手续费（基点），10 基点等于 0.10%。"
+              extra={
+                expandedInfo === "execution"
+                  ? "Basis points charged on both entry and exit (10 bps = 0.10%)."
+                  : undefined
+              }
             >
               <InputNumber min={0} max={100} style={{ width: "100%" }} />
             </Form.Item>
@@ -498,7 +494,11 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
               label="Hold Days"
               name="hold_days"
               style={{ flex: 1 }}
-              extra="English: Maximum number of business days to keep each trade open. 中文：单笔交易最长持有的交易日数量。"
+              extra={
+                expandedInfo === "execution"
+                  ? "Maximum number of business days to keep each trade open."
+                  : undefined
+              }
             >
               <InputNumber min={1} max={10} style={{ width: "100%" }} />
             </Form.Item>
@@ -508,7 +508,11 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
               label="Stop Loss (%)"
               name="stop_loss_pct"
               style={{ flex: 1 }}
-              extra="English: Optional downside limit per trade (e.g. 5 = -5%). Leave blank for none. 中文：选填的单笔止损百分比，留空表示不设止损。"
+              extra={
+                expandedInfo === "execution"
+                  ? "Optional downside limit per trade (e.g. 5 = -5%). Leave blank for none."
+                  : undefined
+              }
             >
               <InputNumber min={0} max={100} style={{ width: "100%" }} placeholder="Optional" />
             </Form.Item>
@@ -516,7 +520,11 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
               label="Take Profit (%)"
               name="take_profit_pct"
               style={{ flex: 1 }}
-              extra="English: Optional upside cap per trade (e.g. 10 = +10%). 中文：选填的单笔止盈百分比，留空表示不设止盈。"
+              extra={
+                expandedInfo === "execution"
+                  ? "Optional upside cap per trade (e.g. 10 = +10%). Leave blank for none."
+                  : undefined
+              }
             >
               <InputNumber min={0} max={200} style={{ width: "100%" }} placeholder="Optional" />
             </Form.Item>
@@ -528,16 +536,17 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
             <div>
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
                 <Text strong>Relative Strength Index (RSI)</Text>
-                <Button type="link" size="small" onClick={() => setInfoModal("rsi")}>
-                  Describe
+                <Button type="link" size="small" onClick={() => toggleInfo("rsi")}>
+                  {expandedInfo === "rsi" ? "Hide Details" : "Describe"}
                 </Button>
               </div>
+              {expandedInfo === "rsi" && <div style={infoPanelStyle}>{renderInfoContent("rsi")}</div>}
               <Form.Item
                 label="Enable RSI"
                 name="enable_rsi"
                 valuePropName="checked"
                 style={{ marginBottom: 12 }}
-                extra="English: Toggle the RSI oscillator. 中文：开启或关闭 RSI 指标。"
+                extra={expandedInfo === "rsi" ? "Toggle the RSI oscillator." : undefined}
               >
                 <Switch />
               </Form.Item>
@@ -545,7 +554,7 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
                 label="RSI Lookback"
                 name="rsi_n"
                 style={{ marginBottom: 12 }}
-                extra="English: Number of days used in the RSI calculation. 中文：RSI 计算所使用的天数。"
+                extra={expandedInfo === "rsi" ? "Number of days used in the RSI calculation." : undefined}
               >
                 <InputNumber min={2} max={100} style={{ width: "100%" }} disabled={!enableRsi} />
               </Form.Item>
@@ -553,7 +562,7 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
                 label="RSI Mode"
                 name={["rsi_rule", "mode"]}
                 style={{ marginBottom: 12 }}
-                extra="English: Choose oversold (buy dips) or overbought (fade rallies). 中文：选择在超卖时买入还是在超买时做反转。"
+                extra={expandedInfo === "rsi" ? "Choose oversold (buy dips) or overbought (fade rallies)." : undefined}
               >
                 <Select
                   options={[
@@ -566,7 +575,11 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
               <Form.Item
                 label="RSI Threshold (0-100)"
                 name={["rsi_rule", "threshold"]}
-                extra="English: Lower values trigger earlier in oversold mode; higher values trigger earlier in overbought mode. 中文：阈值越低越容易在超卖模式触发，越高越容易在超买模式触发。"
+                extra={
+                  expandedInfo === "rsi"
+                    ? "Lower values trigger earlier in oversold mode; higher values trigger earlier in overbought mode."
+                    : undefined
+                }
               >
                 <Slider min={0} max={100} step={1} disabled={!enableRsi} />
               </Form.Item>
@@ -575,34 +588,54 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
             <div>
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
                 <Text strong>Moving Average Convergence Divergence (MACD)</Text>
-                <Button type="link" size="small" onClick={() => setInfoModal("macd")}>
-                  Describe
+                <Button type="link" size="small" onClick={() => toggleInfo("macd")}>
+                  {expandedInfo === "macd" ? "Hide Details" : "Describe"}
                 </Button>
               </div>
+              {expandedInfo === "macd" && <div style={infoPanelStyle}>{renderInfoContent("macd")}</div>}
               <Form.Item
                 label="Enable MACD"
                 name="use_macd"
                 valuePropName="checked"
                 style={{ marginBottom: 12 }}
-                extra="English: Turn MACD on or off. 中文：开启或关闭 MACD 指标。"
+                extra={expandedInfo === "macd" ? "Toggle MACD on or off." : undefined}
               >
                 <Switch />
               </Form.Item>
               <Space style={{ width: "100%", marginBottom: 12 }} size={12}>
-                <Form.Item label="Fast" name="macd_fast" style={{ flex: 1, marginBottom: 0 }} extra="短期 EMA 周期" >
+                <Form.Item
+                  label="Fast"
+                  name="macd_fast"
+                  style={{ flex: 1, marginBottom: 0 }}
+                  extra={expandedInfo === "macd" ? "Fast EMA span." : undefined}
+                >
                   <InputNumber min={1} max={20} style={{ width: "100%" }} disabled={!useMacd} />
                 </Form.Item>
-                <Form.Item label="Slow" name="macd_slow" style={{ flex: 1, marginBottom: 0 }} extra="长期 EMA 周期">
+                <Form.Item
+                  label="Slow"
+                  name="macd_slow"
+                  style={{ flex: 1, marginBottom: 0 }}
+                  extra={expandedInfo === "macd" ? "Slow EMA span." : undefined}
+                >
                   <InputNumber min={1} max={40} style={{ width: "100%" }} disabled={!useMacd} />
                 </Form.Item>
-                <Form.Item label="Signal" name="macd_signal" style={{ flex: 1, marginBottom: 0 }} extra="信号线周期">
+                <Form.Item
+                  label="Signal"
+                  name="macd_signal"
+                  style={{ flex: 1, marginBottom: 0 }}
+                  extra={expandedInfo === "macd" ? "Signal-line smoothing period." : undefined}
+                >
                   <InputNumber min={1} max={20} style={{ width: "100%" }} disabled={!useMacd} />
                 </Form.Item>
               </Space>
               <Form.Item
                 label="MACD Rule"
                 name="macd_rule"
-                extra="English: Choose signal-line crossover or MACD > 0. 中文：选择信号线交叉或 MACD 大于零作为触发条件。"
+                extra={
+                  expandedInfo === "macd"
+                    ? "Choose signal-line crossover or MACD > 0 as the trigger."
+                    : undefined
+                }
               >
                 <Select
                   options={[
@@ -617,23 +650,28 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
             <div>
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
                 <Text strong>On-Balance Volume (OBV)</Text>
-                <Button type="link" size="small" onClick={() => setInfoModal("obv")}>
-                  Describe
+                <Button type="link" size="small" onClick={() => toggleInfo("obv")}>
+                  {expandedInfo === "obv" ? "Hide Details" : "Describe"}
                 </Button>
               </div>
+              {expandedInfo === "obv" && <div style={infoPanelStyle}>{renderInfoContent("obv")}</div>}
               <Form.Item
                 label="Enable OBV"
                 name="use_obv"
                 valuePropName="checked"
                 style={{ marginBottom: 12 }}
-                extra="English: Turn OBV on or off. 中文：开启或关闭 OBV 指标。"
+                extra={expandedInfo === "obv" ? "Toggle OBV on or off." : undefined}
               >
                 <Switch />
               </Form.Item>
               <Form.Item
                 label="OBV Rule"
                 name="obv_rule"
-                extra="English: Decide between OBV crossing its moving average (rise) or turning positive. 中文：选择 OBV 穿越均线或由负转正作为触发条件。"
+                extra={
+                  expandedInfo === "obv"
+                    ? "Decide between OBV crossing its moving average (rise) or turning positive."
+                    : undefined
+                }
               >
                 <Select
                   options={[
@@ -648,24 +686,35 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
             <div>
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
                 <Text strong>Exponential Moving Average Cross (EMA)</Text>
-                <Button type="link" size="small" onClick={() => setInfoModal("ema")}>
-                  Describe
+                <Button type="link" size="small" onClick={() => toggleInfo("ema")}>
+                  {expandedInfo === "ema" ? "Hide Details" : "Describe"}
                 </Button>
               </div>
+              {expandedInfo === "ema" && <div style={infoPanelStyle}>{renderInfoContent("ema")}</div>}
               <Form.Item
                 label="Enable EMA Cross"
                 name="use_ema"
                 valuePropName="checked"
                 style={{ marginBottom: 12 }}
-                extra="English: Toggle the EMA cross strategy. 中文：开启或关闭 EMA 交叉策略。"
+                extra={expandedInfo === "ema" ? "Toggle the EMA cross strategy." : undefined}
               >
                 <Switch />
               </Form.Item>
               <Space style={{ width: "100%" }} size={12}>
-                <Form.Item label="Short" name="ema_short" style={{ flex: 1, marginBottom: 0 }} extra="English: Short-term EMA span. 中文：短期 EMA 的天数。">
+                <Form.Item
+                  label="Short"
+                  name="ema_short"
+                  style={{ flex: 1, marginBottom: 0 }}
+                  extra={expandedInfo === "ema" ? "Short-term EMA span." : undefined}
+                >
                   <InputNumber min={2} max={50} style={{ width: "100%" }} disabled={!useEma} />
                 </Form.Item>
-                <Form.Item label="Long" name="ema_long" style={{ flex: 1, marginBottom: 0 }} extra="English: Long-term EMA span. 中文：长期 EMA 的天数。">
+                <Form.Item
+                  label="Long"
+                  name="ema_long"
+                  style={{ flex: 1, marginBottom: 0 }}
+                  extra={expandedInfo === "ema" ? "Long-term EMA span." : undefined}
+                >
                   <InputNumber min={5} max={200} style={{ width: "100%" }} disabled={!useEma} />
                 </Form.Item>
               </Space>
@@ -674,24 +723,35 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
             <div>
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
                 <Text strong>Average Directional Index (ADX)</Text>
-                <Button type="link" size="small" onClick={() => setInfoModal("adx")}>
-                  Describe
+                <Button type="link" size="small" onClick={() => toggleInfo("adx")}>
+                  {expandedInfo === "adx" ? "Hide Details" : "Describe"}
                 </Button>
               </div>
+              {expandedInfo === "adx" && <div style={infoPanelStyle}>{renderInfoContent("adx")}</div>}
               <Form.Item
                 label="Enable ADX"
                 name="use_adx"
                 valuePropName="checked"
                 style={{ marginBottom: 12 }}
-                extra="English: Toggle ADX trend-strength filter. 中文：开启或关闭 ADX 趋势强度过滤。"
+                extra={expandedInfo === "adx" ? "Toggle the ADX trend-strength filter." : undefined}
               >
                 <Switch />
               </Form.Item>
               <Space style={{ width: "100%" }} size={12}>
-                <Form.Item label="Lookback" name="adx_n" style={{ flex: 1, marginBottom: 0 }} extra="Lookback length">
+                <Form.Item
+                  label="Lookback"
+                  name="adx_n"
+                  style={{ flex: 1, marginBottom: 0 }}
+                  extra={expandedInfo === "adx" ? "Lookback length." : undefined}
+                >
                   <InputNumber min={5} max={50} style={{ width: "100%" }} disabled={!useAdx} />
                 </Form.Item>
-                <Form.Item label="Min ADX" name="adx_min" style={{ flex: 1, marginBottom: 0 }} extra="Minimum ADX value">
+                <Form.Item
+                  label="Min ADX"
+                  name="adx_min"
+                  style={{ flex: 1, marginBottom: 0 }}
+                  extra={expandedInfo === "adx" ? "Minimum ADX value." : undefined}
+                >
                   <InputNumber min={5} max={60} style={{ width: "100%" }} disabled={!useAdx} />
                 </Form.Item>
               </Space>
@@ -700,27 +760,43 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
             <div>
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
                 <Text strong>Aroon Oscillator</Text>
-                <Button type="link" size="small" onClick={() => setInfoModal("aroon")}>
-                  Describe
+                <Button type="link" size="small" onClick={() => toggleInfo("aroon")}>
+                  {expandedInfo === "aroon" ? "Hide Details" : "Describe"}
                 </Button>
               </div>
+              {expandedInfo === "aroon" && <div style={infoPanelStyle}>{renderInfoContent("aroon")}</div>}
               <Form.Item
                 label="Enable Aroon"
                 name="use_aroon"
                 valuePropName="checked"
                 style={{ marginBottom: 12 }}
-                extra="English: Toggle Aroon indicator. 中文：开启或关闭 Aroon 指标。"
+                extra={expandedInfo === "aroon" ? "Toggle the Aroon indicator." : undefined}
               >
                 <Switch />
               </Form.Item>
               <Space style={{ width: "100%" }} size={12}>
-                <Form.Item label="Lookback" name="aroon_n" style={{ flex: 1, marginBottom: 0 }} extra="Lookback days">
+                <Form.Item
+                  label="Lookback"
+                  name="aroon_n"
+                  style={{ flex: 1, marginBottom: 0 }}
+                  extra={expandedInfo === "aroon" ? "Lookback days." : undefined}
+                >
                   <InputNumber min={5} max={50} style={{ width: "100%" }} disabled={!useAroon} />
                 </Form.Item>
-                <Form.Item label="Aroon Up" name="aroon_up" style={{ flex: 1, marginBottom: 0 }} extra="Upper threshold">
+                <Form.Item
+                  label="Aroon Up"
+                  name="aroon_up"
+                  style={{ flex: 1, marginBottom: 0 }}
+                  extra={expandedInfo === "aroon" ? "Upper threshold." : undefined}
+                >
                   <InputNumber min={0} max={100} style={{ width: "100%" }} disabled={!useAroon} />
                 </Form.Item>
-                <Form.Item label="Aroon Down" name="aroon_down" style={{ flex: 1, marginBottom: 0 }} extra="Lower threshold">
+                <Form.Item
+                  label="Aroon Down"
+                  name="aroon_down"
+                  style={{ flex: 1, marginBottom: 0 }}
+                  extra={expandedInfo === "aroon" ? "Lower threshold." : undefined}
+                >
                   <InputNumber min={0} max={100} style={{ width: "100%" }} disabled={!useAroon} />
                 </Form.Item>
               </Space>
@@ -729,34 +805,54 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
             <div>
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
                 <Text strong>Stochastic Oscillator</Text>
-                <Button type="link" size="small" onClick={() => setInfoModal("stoch")}>
-                  Describe
+                <Button type="link" size="small" onClick={() => toggleInfo("stoch")}>
+                  {expandedInfo === "stoch" ? "Hide Details" : "Describe"}
                 </Button>
               </div>
+              {expandedInfo === "stoch" && <div style={infoPanelStyle}>{renderInfoContent("stoch")}</div>}
               <Form.Item
                 label="Enable Stochastic"
                 name="use_stoch"
                 valuePropName="checked"
                 style={{ marginBottom: 12 }}
-                extra="English: Toggle Stochastic oscillator. 中文：开启或关闭随机指标。"
+                extra={expandedInfo === "stoch" ? "Toggle the stochastic oscillator." : undefined}
               >
                 <Switch />
               </Form.Item>
               <Space style={{ width: "100%", marginBottom: 12 }} size={12}>
-                <Form.Item label="%K" name="stoch_k" style={{ flex: 1, marginBottom: 0 }} extra="%K lookback">
+                <Form.Item
+                  label="%K"
+                  name="stoch_k"
+                  style={{ flex: 1, marginBottom: 0 }}
+                  extra={expandedInfo === "stoch" ? "%K lookback." : undefined}
+                >
                   <InputNumber min={5} max={50} style={{ width: "100%" }} disabled={!useStoch} />
                 </Form.Item>
-                <Form.Item label="%D" name="stoch_d" style={{ flex: 1, marginBottom: 0 }} extra="%D smoothing">
+                <Form.Item
+                  label="%D"
+                  name="stoch_d"
+                  style={{ flex: 1, marginBottom: 0 }}
+                  extra={expandedInfo === "stoch" ? "%D smoothing." : undefined}
+                >
                   <InputNumber min={1} max={20} style={{ width: "100%" }} disabled={!useStoch} />
                 </Form.Item>
-                <Form.Item label="Threshold" name="stoch_threshold" style={{ flex: 1, marginBottom: 0 }} extra="Threshold for oversold/overbought">
+                <Form.Item
+                  label="Threshold"
+                  name="stoch_threshold"
+                  style={{ flex: 1, marginBottom: 0 }}
+                  extra={expandedInfo === "stoch" ? "Threshold for oversold/overbought." : undefined}
+                >
                   <InputNumber min={1} max={50} style={{ width: "100%" }} disabled={!useStoch} />
                 </Form.Item>
               </Space>
               <Form.Item
                 label="Rule"
                 name="stoch_rule"
-                extra="English: Decide between signal crossover, oversold, or overbought triggers. 中文：选择交叉信号或超买/超卖触发方式。"
+                extra={
+                  expandedInfo === "stoch"
+                    ? "Decide between signal crossover, oversold, or overbought triggers."
+                    : undefined
+                }
               >
                 <Select
                   options={[
@@ -772,27 +868,40 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
         </Card>
 
         <Card title="Universe Filters" size="small" bordered={false} style={{ marginBottom: 16 }}>
-          <Form.Item label="Sector" name={["filters", "sectors"]} extra="English: Pick industries to include. 中文：选择需要纳入的行业。">
+          <Form.Item label="Sector" name={["filters", "sectors"]} extra="Pick industries to include.">
             <Select mode="multiple" allowClear options={sectorOptions} />
           </Form.Item>
-          <Form.Item label="Market Cap Min ($)" name={["filters", "mcap_min"]} extra="English: Smallest allowed market capitalization. 中文：允许的最小市值。">
+          <Form.Item label="Market Cap Min ($)" name={["filters", "mcap_min"]} extra="Smallest allowed market capitalization.">
             <InputNumber min={0} style={{ width: "100%" }} />
           </Form.Item>
-          <Form.Item label="Market Cap Max ($)" name={["filters", "mcap_max"]} extra="English: Largest allowed market capitalization. 中文：允许的最大市值。">
+          <Form.Item label="Market Cap Max ($)" name={["filters", "mcap_max"]} extra="Largest allowed market capitalization.">
             <InputNumber min={0} style={{ width: "100%" }} />
           </Form.Item>
-          <Form.Item label="Exclude Tickers" name={["filters", "exclude_tickers"]} extra="English: Remove specific symbols (comma separated). 中文：排除特定股票代码，使用逗号或空格分隔。">
+          <Form.Item
+            label="Exclude Tickers"
+            name={["filters", "exclude_tickers"]}
+            extra="Remove specific symbols (comma or space separated)."
+          >
             <Select mode="tags" tokenSeparators={[",", " "]} placeholder="e.g. TSLA, NVDA" />
           </Form.Item>
         </Card>
 
         <Card title="Signal Rules" size="small" bordered={false} style={{ marginBottom: 16 }}>
           <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: 8 }}>
-            <Button type="link" size="small" onClick={() => setInfoModal("signals")}>
-              Describe
+            <Button type="link" size="small" onClick={() => toggleInfo("signals")}>
+              {expandedInfo === "signals" ? "Hide Details" : "Describe"}
             </Button>
           </div>
-          <Form.Item label="Combination Policy" name="policy" extra="English: Decide how indicator votes combine. 中文：决定多个指标如何共同触发。">
+          {expandedInfo === "signals" && <div style={infoPanelStyle}>{renderInfoContent("signals")}</div>}
+          <Form.Item
+            label="Combination Policy"
+            name="policy"
+            extra={
+              expandedInfo === "signals"
+                ? "Decide how indicator votes combine."
+                : undefined
+            }
+          >
             <Select
               options={[
                 { label: "Any", value: "any" },
@@ -801,13 +910,35 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
               ]}
             />
           </Form.Item>
-          <Form.Item label="k" name="k" extra="English: Minimum agreeing indicators when using 'At least k'. 中文：在选择“至少 k 个”时需要满足的指标数量。">
+          <Form.Item
+            label="k"
+            name="k"
+            extra={
+              expandedInfo === "signals" ? "Minimum agreeing indicators when using 'At least k'." : undefined
+            }
+          >
             <InputNumber min={1} max={7} style={{ width: "100%" }} />
           </Form.Item>
-          <Form.Item label="Max Horizon (days)" name="max_horizon" extra="English: Longest forward-return horizon to compute (also bounds hold days). 中文：计算前瞻收益的最远天数，同时限制持仓天数。">
+          <Form.Item
+            label="Max Horizon (days)"
+            name="max_horizon"
+            extra={
+              expandedInfo === "signals"
+                ? "Longest forward-return horizon to compute (also bounds hold days)."
+                : undefined
+            }
+          >
             <InputNumber min={1} max={10} style={{ width: "100%" }} />
           </Form.Item>
-          <Form.Item label="Histogram Horizon (days)" name="hist_horizon" extra="English: Choose which horizon fills the return distribution. 中文：选择用于绘制收益分布的前瞻天数。">
+          <Form.Item
+            label="Histogram Horizon (days)"
+            name="hist_horizon"
+            extra={
+              expandedInfo === "signals"
+                ? "Choose which horizon fills the return distribution."
+                : undefined
+            }
+          >
             <InputNumber min={1} max={10} style={{ width: "100%" }} />
           </Form.Item>
         </Card>
@@ -823,40 +954,6 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
         </Space>
       </Form>
 
-      <Modal
-        open={infoModal !== null}
-        onCancel={() => setInfoModal(null)}
-        footer={null}
-        width={720}
-        title={(() => {
-          switch (infoModal) {
-            case "strategy":
-              return "Strategy Presets / 策略预设";
-            case "execution":
-              return "Execution Settings / 执行参数";
-            case "rsi":
-              return "RSI Guide / RSI 指南";
-            case "macd":
-              return "MACD Guide / MACD 指南";
-            case "obv":
-              return "OBV Guide / OBV 指南";
-            case "ema":
-              return "EMA Cross Guide / EMA 交叉指南";
-            case "adx":
-              return "ADX Guide / ADX 指南";
-            case "aroon":
-              return "Aroon Guide / Aroon 指南";
-            case "stoch":
-              return "Stochastic Guide / 随机指标指南";
-            case "signals":
-              return "Signal Combination / 信号组合";
-            default:
-              return "";
-          }
-        })()}
-      >
-        {renderInfoContent()}
-      </Modal>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- remove Chinese text from the signal help modal and all sidebar guidance
- replace modal-based help with inline panels that expand only when Describe buttons are clicked
- gate all sidebar field hint text behind the relevant Describe toggles and simplify filter copy

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d47270c5d0832b91c66ea3367e6ae1