### PR TITLE
Add sidebar parameter export and responsive indicator layout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,12 +13,14 @@ import type { ECharts } from "echarts";
 import HistogramChart from "./components/HistogramChart";
 import IndicatorStatsTable from "./components/IndicatorStatsTable";
 import { downloadCSV, downloadJSON, downloadImage } from "./utils/download";
+import { formatCurrency, formatNumber, formatPercent } from "./utils/format";
 
 const { Title, Text, Paragraph } = Typography;
 
 const App = () => {
   const [loading, setLoading] = useState(false);
   const [response, setResponse] = useState<BacktestResponse | null>(null);
+  const [lastRunConfig, setLastRunConfig] = useState<BacktestRequest | null>(null);
   const [signalsInfoVisible, setSignalsInfoVisible] = useState(false);
   const [showPriceLine, setShowPriceLine] = useState(true);
   const [showBuySignals, setShowBuySignals] = useState(true);
@@ -30,6 +32,7 @@ const App = () => {
       setLoading(true);
       const { data } = await api.post<BacktestResponse>("/run_backtest", payload);
       setResponse(data);
+      setLastRunConfig(payload);
       message.success("Backtest complete");
     } catch (error: any) {
       const detail = error?.response?.data?.detail || error.message;
@@ -124,6 +127,79 @@ const App = () => {
     downloadCSV("indicator_statistics.csv", ["horizon", "metric", "value"], rows);
   };
 
+  const histogramBins = response?.histogram?.bin_count ?? lastRunConfig?.hist_bins ?? null;
+  const summaryItems = response
+    ? [
+        { label: "Universe size", value: formatNumber(response.universe_size, 0) },
+        { label: "Trades generated", value: formatNumber(response.trades_count, 0) },
+        { label: "Initial capital", value: formatCurrency(response.initial_capital, 0) },
+        { label: "Ending equity", value: formatCurrency(response.ending_equity, 0) },
+        { label: "Total return", value: formatPercent(response.total_return, 2) },
+        { label: "Total fees", value: formatCurrency(response.total_fees, 0) },
+        ...(response.histogram
+          ? [{ label: "Histogram horizon", value: `${response.histogram.horizon}d` }]
+          : []),
+        ...(histogramBins !== null
+          ? [{ label: "Histogram bins", value: formatNumber(histogramBins, 0) }]
+          : []),
+      ]
+    : [];
+
+  const capitalDisplay = formatCurrency(
+    lastRunConfig?.capital ?? response?.initial_capital ?? 0,
+    0,
+  );
+  const holdDaysDisplay =
+    lastRunConfig?.hold_days !== undefined && lastRunConfig?.hold_days !== null
+      ? formatNumber(lastRunConfig.hold_days, 0)
+      : "—";
+  const feeDisplay =
+    lastRunConfig?.fee_bps !== undefined && lastRunConfig?.fee_bps !== null
+      ? `${formatNumber(lastRunConfig.fee_bps, 2)} bps`
+      : "—";
+  const stopLossDisplay =
+    lastRunConfig?.stop_loss_pct !== undefined && lastRunConfig?.stop_loss_pct !== null
+      ? formatPercent(lastRunConfig.stop_loss_pct, 1)
+      : "—";
+  const takeProfitDisplay =
+    lastRunConfig?.take_profit_pct !== undefined && lastRunConfig?.take_profit_pct !== null
+      ? formatPercent(lastRunConfig.take_profit_pct, 1)
+      : "—";
+  const fallbackHistHorizon = lastRunConfig?.indicators?.hist_horizon as number | undefined;
+  const histHorizonDisplay = response?.histogram
+    ? `${response.histogram.horizon}d`
+    : fallbackHistHorizon !== undefined && fallbackHistHorizon !== null
+      ? `${fallbackHistHorizon}d`
+      : "—";
+  const binsDisplay = histogramBins !== null ? formatNumber(histogramBins, 0) : "—";
+
+  const runSettingItems = lastRunConfig
+    ? [
+        { label: "Start date", value: lastRunConfig.start },
+        { label: "End date", value: lastRunConfig.end },
+        { label: "Initial capital", value: capitalDisplay },
+        { label: "Hold days", value: holdDaysDisplay },
+        { label: "Fee (bps)", value: feeDisplay },
+        { label: "Stop loss", value: stopLossDisplay },
+        { label: "Take profit", value: takeProfitDisplay },
+        { label: "Histogram horizon", value: histHorizonDisplay },
+        { label: "Histogram bins", value: binsDisplay },
+      ]
+    : [];
+
+  const histogramInfoItems = response?.histogram
+    ? [
+        {
+          label: "Window",
+          value: lastRunConfig ? `${lastRunConfig.start} → ${lastRunConfig.end}` : "—",
+        },
+        { label: "Horizon", value: `${response.histogram.horizon}d` },
+        { label: "Hold days", value: holdDaysDisplay },
+        { label: "Fee", value: feeDisplay },
+        { label: "Bins", value: binsDisplay },
+      ]
+    : [];
+
   return (
     <ConfigProvider
       theme={{
@@ -154,31 +230,42 @@ const App = () => {
 
               {response && (
                 <div className="results-container">
-                  <Card className="result-card">
+                  <Card className="result-card overview-card">
                     <div className="card-header">
-                      <Title level={3}>Aggregated Results</Title>
-                      <Space>
+                      <Title level={3}>Backtest Overview</Title>
+                      <Space size={8} wrap>
                         <Button size="small" onClick={handleDownloadSummary}>
                           Download JSON
                         </Button>
+                        <Button size="small" onClick={handleDownloadMetrics}>
+                          Metrics CSV
+                        </Button>
                       </Space>
                     </div>
-                    <div className="summary-stats">
-                      <div>
-                        <span>Universe size</span>
-                        <strong>{response.universe_size}</strong>
+                    <div className="overview-grid">
+                      <div className="overview-summary">
+                        {summaryItems.map((item) => (
+                          <div key={item.label} className="summary-item">
+                            <span>{item.label}</span>
+                            <strong>{item.value}</strong>
+                          </div>
+                        ))}
                       </div>
-                      <div>
-                        <span>Trades generated</span>
-                        <strong>{response.trades_count}</strong>
-                      </div>
-                      {response.histogram && (
-                        <div>
-                          <span>Histogram horizon</span>
-                          <strong>{`${response.histogram.horizon}d`}</strong>
+                      {runSettingItems.length > 0 && (
+                        <div className="overview-settings">
+                          <h4>Run settings</h4>
+                          <dl className="settings-list">
+                            {runSettingItems.map((item) => (
+                              <div key={item.label} className="settings-list__item">
+                                <dt>{item.label}</dt>
+                                <dd>{item.value}</dd>
+                              </div>
+                            ))}
+                          </dl>
                         </div>
                       )}
                     </div>
+                    <MetricsTable metrics={response.metrics} />
                   </Card>
 
                   {response.histogram && (
@@ -194,6 +281,16 @@ const App = () => {
                           </Button>
                         </Space>
                       </div>
+                      {histogramInfoItems.length > 0 && (
+                        <div className="histogram-info">
+                          {histogramInfoItems.map((item) => (
+                            <div key={item.label} className="info-pill">
+                              <span className="info-pill__label">{item.label}</span>
+                              <span className="info-pill__value">{item.value}</span>
+                            </div>
+                          ))}
+                        </div>
+                      )}
                       <HistogramChart
                         data={response.histogram}
                         loading={loading}
@@ -202,6 +299,18 @@ const App = () => {
                           histogramChartRef.current = instance;
                         }}
                       />
+                    </Card>
+                  )}
+
+                  {response.indicator_statistics && Object.keys(response.indicator_statistics).length > 0 && (
+                    <Card className="result-card">
+                      <div className="card-header">
+                        <Title level={4}>Indicator Statistics</Title>
+                        <Button size="small" onClick={handleDownloadIndicatorStats}>
+                          Download CSV
+                        </Button>
+                      </div>
+                      <IndicatorStatsTable stats={response.indicator_statistics} />
                     </Card>
                   )}
 
@@ -225,16 +334,6 @@ const App = () => {
                       <DrawdownChart data={response.drawdown_curve} loading={loading} />
                     </Card>
                   </div>
-
-                  <Card className="result-card">
-                    <div className="card-header">
-                      <Title level={4}>Performance Metrics</Title>
-                      <Button size="small" onClick={handleDownloadMetrics}>
-                        Download CSV
-                      </Button>
-                    </div>
-                    <MetricsTable metrics={response.metrics} />
-                  </Card>
 
                   <Card className="result-card">
                     <div className="card-header">
@@ -268,18 +367,6 @@ const App = () => {
                       showSells={showSellSignals}
                     />
                   </Card>
-
-                  {response.indicator_statistics && Object.keys(response.indicator_statistics).length > 0 && (
-                    <Card className="result-card">
-                      <div className="card-header">
-                        <Title level={4}>Indicator Statistics</Title>
-                        <Button size="small" onClick={handleDownloadIndicatorStats}>
-                          Download CSV
-                        </Button>
-                      </div>
-                      <IndicatorStatsTable stats={response.indicator_statistics} />
-                    </Card>
-                  )}
 
                   <Card className="result-card">
                     <div className="card-header">

--- a/frontend/src/components/DrawdownChart.tsx
+++ b/frontend/src/components/DrawdownChart.tsx
@@ -3,6 +3,7 @@ import ReactECharts from "echarts-for-react";
 import type { ECharts } from "echarts";
 import { Spin, Empty } from "antd";
 import { TimeSeries } from "../types";
+import { formatDateYYMMDD, formatPercent } from "../utils/format";
 
 interface Props {
   data?: TimeSeries | null;
@@ -22,7 +23,7 @@ const DrawdownChart = ({ data, loading, onReady }: Props) => {
   const option = {
     tooltip: {
       trigger: "axis",
-      valueFormatter: (v: number) => `${(v * 100).toFixed(2)}%`,
+      valueFormatter: (v: number) => formatPercent(v, 2),
     },
     dataZoom: [
       {
@@ -43,10 +44,21 @@ const DrawdownChart = ({ data, loading, onReady }: Props) => {
         moveHandleSize: 10,
       },
     ],
-    xAxis: { type: "category", data: data.dates },
+    xAxis: {
+      type: "category",
+      data: data.dates,
+      axisLabel: {
+        formatter: (value: string) => formatDateYYMMDD(value),
+        hideOverlap: true,
+      },
+      splitLine: { show: true, lineStyle: { color: "#ffe4e6" } },
+    },
     yAxis: {
       type: "value",
-      axisLabel: { formatter: (value: number) => `${(value * 100).toFixed(0)}%` },
+      axisLabel: {
+        formatter: (value: number) => formatPercent(value, 0),
+      },
+      splitLine: { show: true, lineStyle: { color: "#ffe4e6" } },
     },
     series: [
       {
@@ -57,6 +69,12 @@ const DrawdownChart = ({ data, loading, onReady }: Props) => {
         data: data.values,
       },
     ],
+    grid: {
+      top: 40,
+      left: 72,
+      right: 28,
+      bottom: 64,
+    },
   };
 
   const handleReady = (instance: ECharts) => {

--- a/frontend/src/components/EquityChart.tsx
+++ b/frontend/src/components/EquityChart.tsx
@@ -3,6 +3,7 @@ import ReactECharts from "echarts-for-react";
 import type { ECharts } from "echarts";
 import { Spin, Empty } from "antd";
 import { TimeSeries } from "../types";
+import { formatCurrency, formatDateYYMMDD } from "../utils/format";
 
 interface Props {
   data?: TimeSeries | null;
@@ -21,7 +22,10 @@ const EquityChart = ({ data, loading, onReady }: Props) => {
   }
 
   const option = {
-    tooltip: { trigger: "axis" },
+    tooltip: {
+      trigger: "axis",
+      valueFormatter: (value: number) => formatCurrency(value, 0),
+    },
     toolbox: { feature: { saveAsImage: {} } },
     dataZoom: [
       {
@@ -42,8 +46,29 @@ const EquityChart = ({ data, loading, onReady }: Props) => {
         moveHandleSize: 10,
       },
     ],
-    xAxis: { type: "category", data: data.dates },
-    yAxis: { type: "value", scale: true },
+    xAxis: {
+      type: "category",
+      data: data.dates,
+      axisLabel: {
+        formatter: (value: string) => formatDateYYMMDD(value),
+        hideOverlap: true,
+      },
+      splitLine: { show: true, lineStyle: { color: "#e2e8f0" } },
+    },
+    yAxis: {
+      type: "value",
+      scale: true,
+      axisLabel: {
+        formatter: (value: number) => formatCurrency(value, 0),
+      },
+      splitLine: { show: true, lineStyle: { color: "#e2e8f0" } },
+    },
+    grid: {
+      top: 40,
+      left: 72,
+      right: 28,
+      bottom: 64,
+    },
     series: [
       {
         type: "line",

--- a/frontend/src/components/HistogramChart.tsx
+++ b/frontend/src/components/HistogramChart.tsx
@@ -46,7 +46,7 @@ const HistogramChart = ({ data, loading, onReady, height = 400 }: Props) => {
     },
     yAxis: {
       type: "value",
-      name: "Frequency",
+      name: "Trades",
       nameLocation: "middle",
       nameGap: 48,
     },
@@ -91,6 +91,7 @@ const HistogramChart = ({ data, loading, onReady, height = 400 }: Props) => {
             );
           })}
           <Statistic title="Samples" value={data.sample_size} />
+          <Statistic title="Bins" value={data.bin_count} />
         </div>
       )}
     </div>

--- a/frontend/src/components/MetricsTable.tsx
+++ b/frontend/src/components/MetricsTable.tsx
@@ -1,5 +1,6 @@
 import { Empty } from "antd";
 import { Metrics } from "../types";
+import { formatCurrency, formatNumber, formatPercent } from "../utils/format";
 
 interface Props {
   metrics: Metrics;
@@ -15,22 +16,23 @@ const percentKeys = new Set([
 
 const MetricsTable = ({ metrics }: Props) => {
   const entries = Object.entries(metrics ?? {});
-  if (!entries.length) {
+  const displayEntries = entries.filter(([key]) => key !== "ending_equity");
+  if (!displayEntries.length) {
     return <Empty description="No metrics" />;
   }
   return (
     <div className="metrics-grid">
-      {entries.map(([key, value]) => {
+      {displayEntries.map(([key, value]) => {
         let display: string | number = value;
         if (typeof value === "number") {
-          if (key === "ending_equity") {
-            display = value.toFixed(2);
-          } else if (key === "sharpe") {
+          if (key === "sharpe") {
             display = value.toFixed(2);
           } else if (percentKeys.has(key)) {
-            display = `${(value * 100).toFixed(2)}%`;
+            display = formatPercent(value, 2);
+          } else if (key.endsWith("_usd")) {
+            display = formatCurrency(value, 0);
           } else {
-            display = value.toFixed(4);
+            display = formatNumber(value, 4);
           }
         }
         return (

--- a/frontend/src/components/SidebarForm.tsx
+++ b/frontend/src/components/SidebarForm.tsx
@@ -16,6 +16,7 @@ import {
 import dayjs, { Dayjs } from "dayjs";
 import { api } from "../api/client";
 import { BacktestRequest, Filters, RSIRule, UniverseMeta } from "../types";
+import { downloadCSV } from "../utils/download";
 
 const { RangePicker } = DatePicker;
 const { Paragraph, Text } = Typography;
@@ -136,6 +137,110 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
     const values = form.getFieldsValue();
     localStorage.setItem(DEFAULT_PRESET_KEY, JSON.stringify(values));
     message.success("Preset saved locally");
+  };
+
+  const handleDownloadParameters = () => {
+    const values = form.getFieldsValue(true);
+
+    const strategyLabelMap: Record<string, string> = {
+      mean_reversion: "Mean Reversion",
+      momentum: "Momentum",
+      multifactor: "Multifactor",
+    };
+
+    const policyLabelMap: Record<string, string> = {
+      any: "Any",
+      all: "All",
+      atleast_k: "At least k",
+    };
+
+    const macdRuleLabels: Record<string, string> = {
+      signal: "Signal Crossover",
+      positive: "MACD > 0",
+    };
+
+    const obvRuleLabels: Record<string, string> = {
+      rise: "OBV crosses above its moving average",
+      positive: "OBV turns positive",
+    };
+
+    const stochRuleLabels: Record<string, string> = {
+      signal: "Signal crossover",
+      oversold: "Oversold",
+      overbought: "Overbought",
+    };
+
+    const rsiModeLabels: Record<string, string> = {
+      oversold: "Oversold (<= threshold)",
+      overbought: "Overbought (>= threshold)",
+    };
+
+    const yesNo = (value: boolean | undefined) => (value ? "Yes" : "No");
+    const percentValue = (value?: number | null) =>
+      value !== undefined && value !== null ? `${value}%` : "—";
+    const numericValue = (value?: number | null) =>
+      value !== undefined && value !== null ? `${value}` : "—";
+    const listValue = (value?: string[] | null) =>
+      value && value.length ? value.join(", ") : "—";
+
+    const startDate = values.date?.[0] ? values.date[0].format("YYYY-MM-DD") : "—";
+    const endDate = values.date?.[1] ? values.date[1].format("YYYY-MM-DD") : "—";
+
+    const rows: Array<{ section: string; label: string; value: string }> = [
+      { section: "Strategy", label: "Strategy", value: strategyLabelMap[values.strategy] ?? values.strategy ?? "—" },
+      { section: "Strategy", label: "Start date", value: startDate },
+      { section: "Strategy", label: "End date", value: endDate },
+      { section: "Execution", label: "Initial capital", value: values.capital !== undefined && values.capital !== null ? `$${values.capital.toLocaleString()}` : "—" },
+      { section: "Execution", label: "Fee (bps)", value: numericValue(values.fee_bps) },
+      { section: "Execution", label: "Hold days", value: numericValue(values.hold_days) },
+      { section: "Execution", label: "Stop loss", value: percentValue(values.stop_loss_pct) },
+      { section: "Execution", label: "Take profit", value: percentValue(values.take_profit_pct) },
+      { section: "Indicators", label: "Enable RSI", value: yesNo(values.enable_rsi) },
+      { section: "Indicators", label: "RSI lookback", value: numericValue(values.rsi_n) },
+      {
+        section: "Indicators",
+        label: "RSI mode",
+        value: values.rsi_rule?.mode ? rsiModeLabels[values.rsi_rule.mode] ?? values.rsi_rule.mode : "—",
+      },
+      { section: "Indicators", label: "RSI threshold", value: numericValue(values.rsi_rule?.threshold) },
+      { section: "Indicators", label: "Enable MACD", value: yesNo(values.use_macd) },
+      { section: "Indicators", label: "MACD fast", value: numericValue(values.macd_fast) },
+      { section: "Indicators", label: "MACD slow", value: numericValue(values.macd_slow) },
+      { section: "Indicators", label: "MACD signal", value: numericValue(values.macd_signal) },
+      { section: "Indicators", label: "MACD rule", value: macdRuleLabels[values.macd_rule] ?? values.macd_rule ?? "—" },
+      { section: "Indicators", label: "Enable OBV", value: yesNo(values.use_obv) },
+      { section: "Indicators", label: "OBV rule", value: obvRuleLabels[values.obv_rule] ?? values.obv_rule ?? "—" },
+      { section: "Indicators", label: "Enable EMA", value: yesNo(values.use_ema) },
+      { section: "Indicators", label: "EMA short", value: numericValue(values.ema_short) },
+      { section: "Indicators", label: "EMA long", value: numericValue(values.ema_long) },
+      { section: "Indicators", label: "Enable ADX", value: yesNo(values.use_adx) },
+      { section: "Indicators", label: "ADX lookback", value: numericValue(values.adx_n) },
+      { section: "Indicators", label: "ADX min", value: numericValue(values.adx_min) },
+      { section: "Indicators", label: "Enable Aroon", value: yesNo(values.use_aroon) },
+      { section: "Indicators", label: "Aroon lookback", value: numericValue(values.aroon_n) },
+      { section: "Indicators", label: "Aroon up", value: numericValue(values.aroon_up) },
+      { section: "Indicators", label: "Aroon down", value: numericValue(values.aroon_down) },
+      { section: "Indicators", label: "Enable Stochastic", value: yesNo(values.use_stoch) },
+      { section: "Indicators", label: "%K", value: numericValue(values.stoch_k) },
+      { section: "Indicators", label: "%D", value: numericValue(values.stoch_d) },
+      { section: "Indicators", label: "Stochastic threshold", value: numericValue(values.stoch_threshold) },
+      { section: "Indicators", label: "Stochastic rule", value: stochRuleLabels[values.stoch_rule] ?? values.stoch_rule ?? "—" },
+      { section: "Universe filters", label: "Sectors", value: listValue(values.filters?.sectors) },
+      { section: "Universe filters", label: "Market cap min", value: values.filters?.mcap_min !== undefined && values.filters?.mcap_min !== null ? `$${values.filters.mcap_min.toLocaleString()}` : "—" },
+      { section: "Universe filters", label: "Market cap max", value: values.filters?.mcap_max !== undefined && values.filters?.mcap_max !== null ? `$${values.filters.mcap_max.toLocaleString()}` : "—" },
+      { section: "Universe filters", label: "Exclude tickers", value: listValue(values.filters?.exclude_tickers) },
+      { section: "Signal rules", label: "Combination policy", value: policyLabelMap[values.policy] ?? values.policy ?? "—" },
+      { section: "Signal rules", label: "k", value: numericValue(values.k) },
+      { section: "Signal rules", label: "Max horizon", value: numericValue(values.max_horizon) },
+      { section: "Signal rules", label: "Histogram horizon", value: numericValue(values.hist_horizon) },
+      { section: "Signal rules", label: "Histogram bins", value: numericValue(values.hist_bins) },
+    ];
+
+    downloadCSV(
+      "backtest_parameters.csv",
+      ["Section", "Parameter", "Value"],
+      rows.map((row) => [row.section, row.label, row.value])
+    );
   };
 
   const handleStrategyChange = (value: string) => {
@@ -278,6 +383,7 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
       hold_days: values.hold_days,
       stop_loss_pct: stopLoss,
       take_profit_pct: takeProfit,
+      hist_bins: values.hist_bins,
     };
 
     await onSubmit(payload);
@@ -592,6 +698,7 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
           k: 2,
           max_horizon: 10,
           hist_horizon: 1,
+          hist_bins: 20,
           filters: {},
         }}
         style={{ padding: "0 16px", height: "100%", overflowY: "auto" }}
@@ -667,9 +774,9 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
         </Card>
 
         <Card title="Indicators" size="small" bordered={false} style={{ marginBottom: 16 }}>
-          <Space direction="vertical" size={24} style={{ width: "100%" }}>
-            <div>
-              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
+          <div className="indicator-grid">
+            <div className="indicator-tile">
+              <div className="indicator-tile__header">
                 <Text strong>Relative Strength Index (RSI)</Text>
                 <Button type="link" size="small" onClick={() => openInfo("rsi")}>
                   Describe
@@ -711,8 +818,8 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
               </Form.Item>
             </div>
 
-            <div>
-              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
+            <div className="indicator-tile">
+              <div className="indicator-tile__header">
                 <Text strong>Moving Average Convergence Divergence (MACD)</Text>
                 <Button type="link" size="small" onClick={() => openInfo("macd")}>
                   Describe
@@ -763,8 +870,8 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
               </Form.Item>
             </div>
 
-            <div>
-              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
+            <div className="indicator-tile">
+              <div className="indicator-tile__header">
                 <Text strong>On-Balance Volume (OBV)</Text>
                 <Button type="link" size="small" onClick={() => openInfo("obv")}>
                   Describe
@@ -792,8 +899,8 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
               </Form.Item>
             </div>
 
-            <div>
-              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
+            <div className="indicator-tile">
+              <div className="indicator-tile__header">
                 <Text strong>Exponential Moving Average Cross (EMA)</Text>
                 <Button type="link" size="small" onClick={() => openInfo("ema")}>
                   Describe
@@ -825,8 +932,8 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
               </Space>
             </div>
 
-            <div>
-              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
+            <div className="indicator-tile">
+              <div className="indicator-tile__header">
                 <Text strong>Average Directional Index (ADX)</Text>
                 <Button type="link" size="small" onClick={() => openInfo("adx")}>
                   Describe
@@ -858,8 +965,8 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
               </Space>
             </div>
 
-            <div>
-              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
+            <div className="indicator-tile">
+              <div className="indicator-tile__header">
                 <Text strong>Aroon Oscillator</Text>
                 <Button type="link" size="small" onClick={() => openInfo("aroon")}>
                   Describe
@@ -898,8 +1005,8 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
               </Space>
             </div>
 
-            <div>
-              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
+            <div className="indicator-tile">
+              <div className="indicator-tile__header">
                 <Text strong>Stochastic Oscillator</Text>
                 <Button type="link" size="small" onClick={() => openInfo("stoch")}>
                   Describe
@@ -950,7 +1057,7 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
                 />
               </Form.Item>
             </div>
-          </Space>
+          </div>
         </Card>
 
         <Card title="Universe Filters" size="small" bordered={false} style={{ marginBottom: 16 }}>
@@ -1013,17 +1120,27 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
           >
             <InputNumber min={1} max={10} style={{ width: "100%" }} />
           </Form.Item>
+          <Form.Item
+            label="Histogram Bins"
+            name="hist_bins"
+            extra="Number of buckets when summarising forward returns."
+          >
+            <InputNumber min={5} max={60} style={{ width: "100%" }} />
+          </Form.Item>
         </Card>
 
-        <Space style={{ width: "100%", justifyContent: "space-between", marginBottom: 24 }}>
-          <Space>
+        <div className="sidebar-actions">
+          <div className="sidebar-actions__group">
             <Button type="primary" htmlType="submit" loading={loading}>
               Run Backtest
             </Button>
             <Button onClick={handleReset}>Reset</Button>
-          </Space>
-          <Button onClick={handleSavePreset}>Save Preset</Button>
-        </Space>
+          </div>
+          <div className="sidebar-actions__group">
+            <Button onClick={handleDownloadParameters}>Download Parameters</Button>
+            <Button onClick={handleSavePreset}>Save Preset</Button>
+          </div>
+        </div>
       </Form>
 
     </>

--- a/frontend/src/components/SignalChart.tsx
+++ b/frontend/src/components/SignalChart.tsx
@@ -1,8 +1,9 @@
-import React, { useRef } from "react";
+import React, { useMemo, useRef } from "react";
 import ReactECharts from "echarts-for-react";
 import type { ECharts } from "echarts";
 import { Empty } from "antd";
 import { Signal, TimeSeries } from "../types";
+import { formatDateYYMMDD } from "../utils/format";
 
 interface Props {
   priceSeries?: TimeSeries | null;
@@ -24,6 +25,14 @@ const SignalChart = ({ priceSeries, signals, showPrice = true, showBuys = true, 
   const sellData = sells.map((s) => [s.date, s.price, s.symbol]);
 
   const series: any[] = [];
+  const totalPoints = priceSeries.dates.length;
+  const window = Math.min(14, totalPoints);
+  const defaultStart = useMemo(() => {
+    if (totalPoints <= window) {
+      return 0;
+    }
+    return ((totalPoints - window) / totalPoints) * 100;
+  }, [totalPoints, window]);
   if (showPrice) {
     series.push({
       type: "line",
@@ -85,6 +94,8 @@ const SignalChart = ({ priceSeries, signals, showPrice = true, showBuys = true, 
         zoomOnMouseWheel: false,
         moveOnMouseWheel: true,
         moveOnMouseMove: true,
+        start: defaultStart,
+        end: 100,
       },
       {
         type: "slider",
@@ -94,9 +105,18 @@ const SignalChart = ({ priceSeries, signals, showPrice = true, showBuys = true, 
         handleSize: 14,
         handleStyle: { color: "#4c6ef5" },
         moveHandleSize: 10,
+        start: defaultStart,
+        end: 100,
       },
     ],
-    xAxis: { type: "category", data: priceSeries.dates },
+    xAxis: {
+      type: "category",
+      data: priceSeries.dates,
+      axisLabel: {
+        formatter: (value: string) => formatDateYYMMDD(value),
+        hideOverlap: true,
+      },
+    },
     yAxis: { type: "value", scale: true },
     series,
   };

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -114,22 +114,114 @@ body {
   right: 8px;
 }
 
-.summary-stats {
-  display: flex;
-  gap: 32px;
-  flex-wrap: wrap;
+.overview-card .metrics-grid {
+  margin-top: 24px;
+}
+
+.overview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
   margin-top: 12px;
 }
 
-.summary-stats span {
+.overview-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.summary-item {
+  padding: 16px;
+  border-radius: 10px;
+  background: #eef2ff;
+  border: 1px solid #dbe1ff;
+}
+
+.summary-item span {
   display: block;
-  font-size: 13px;
+  font-size: 12px;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.summary-item strong {
+  display: block;
+  font-size: 20px;
+  color: #0f172a;
+  margin-top: 6px;
+}
+
+.overview-settings {
+  border: 1px solid #dbe1ff;
+  border-radius: 10px;
+  background: #f8faff;
+  padding: 16px 20px;
+}
+
+.overview-settings h4 {
+  margin: 0 0 12px 0;
+  font-size: 16px;
+  color: #1d3fae;
+}
+
+.settings-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px 16px;
+  margin: 0;
+}
+
+.settings-list__item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.settings-list__item dt {
+  margin: 0;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
   color: #6b7280;
 }
 
-.summary-stats strong {
-  display: block;
-  font-size: 20px;
+.settings-list__item dd {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.histogram-info {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.info-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: #eef2ff;
+  border: 1px solid #dbe1ff;
+}
+
+.info-pill__label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #1d3fae;
+  font-weight: 600;
+}
+
+.info-pill__value {
+  font-size: 13px;
+  font-weight: 600;
   color: #0f172a;
 }
 
@@ -173,6 +265,45 @@ body {
 
 .resize-handle:hover {
   background: #4c6ef5;
+}
+
+.indicator-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.indicator-tile {
+  border: 1px solid #dbe1ff;
+  border-radius: 10px;
+  background: #f8faff;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.indicator-tile__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+
+.sidebar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.sidebar-actions__group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -25,6 +25,7 @@ export interface BacktestRequest {
   hold_days?: number;
   stop_loss_pct?: number;
   take_profit_pct?: number;
+  hist_bins?: number;
 }
 
 export interface TimeSeries {
@@ -65,6 +66,7 @@ export interface HistogramPayload {
   buckets: HistogramBucket[];
   stats: Record<string, number>;
   sample_size: number;
+  bin_count: number;
 }
 
 export interface BacktestResponse {
@@ -78,6 +80,10 @@ export interface BacktestResponse {
   indicator_statistics?: Record<string, Record<string, number>>;
   universe_size: number;
   trades_count: number;
+  initial_capital: number;
+  ending_equity: number;
+  total_return: number;
+  total_fees: number;
 }
 
 export interface UniverseMeta {

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,0 +1,33 @@
+const BASE_LOCALE = "en-US";
+
+export const formatCurrency = (value: number | undefined | null, fractionDigits = 0) => {
+  const numeric = Number.isFinite(value as number) ? (value as number) : 0;
+  return new Intl.NumberFormat(BASE_LOCALE, {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  }).format(numeric);
+};
+
+export const formatPercent = (value: number | undefined | null, fractionDigits = 2) => {
+  const numeric = Number.isFinite(value as number) ? (value as number) : 0;
+  return new Intl.NumberFormat(BASE_LOCALE, {
+    style: "percent",
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  }).format(numeric);
+};
+
+export const formatNumber = (value: number | undefined | null, fractionDigits = 0) => {
+  const numeric = Number.isFinite(value as number) ? (value as number) : 0;
+  return new Intl.NumberFormat(BASE_LOCALE, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: fractionDigits,
+  }).format(numeric);
+};
+
+export const formatDateYYMMDD = (isoDate: string) => {
+  if (!isoDate) return "";
+  return isoDate.slice(2).replace(/-/g, "");
+};


### PR DESCRIPTION
## Summary
- add a CSV export button in the sidebar that captures the current backtest parameters
- restructure the indicator section into a responsive grid with styling hooks for wider viewports

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_b_68dc3222ede4832b94b77af8e3cb9295