### PR TITLE
feat: add parameter download and responsive indicators

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -201,6 +201,32 @@ body {
   margin-bottom: 16px;
 }
 
+.indicator-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.indicator-grid__item {
+  background: #f9faff;
+  border: 1px solid #e2e7ff;
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.indicator-grid__item .ant-form-item {
+  margin-bottom: 0;
+}
+
+.indicator-grid__item .ant-form-item + .ant-form-item,
+.indicator-grid__item .ant-form-item + .ant-space,
+.indicator-grid__item .ant-space + .ant-form-item {
+  margin-top: 12px;
+}
+
 .info-pill {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add a download helper that exports the active sidebar selections as a CSV table
- replace the indicator stack with a responsive grid so more cards fit per row on wide viewports
- style indicator sections to keep spacing consistent while adapting to the new grid layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68de09636318832bb25fc4de4104a424