### PR TITLE
Improve sidebar layout and add report export

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,8 +12,9 @@ import TradesTable from "./components/TradesTable";
 import type { ECharts } from "echarts";
 import HistogramChart from "./components/HistogramChart";
 import IndicatorStatsTable from "./components/IndicatorStatsTable";
-import { downloadCSV, downloadJSON, downloadImage } from "./utils/download";
+import { downloadCSV, downloadJSON, downloadImage, createCSVContent } from "./utils/download";
 import { formatCurrency, formatNumber, formatPercent } from "./utils/format";
+import { buildSelectionRows } from "./utils/report";
 
 const { Title, Text, Paragraph } = Typography;
 
@@ -21,19 +22,28 @@ const App = () => {
   const [loading, setLoading] = useState(false);
   const [response, setResponse] = useState<BacktestResponse | null>(null);
   const [lastRunConfig, setLastRunConfig] = useState<BacktestRequest | null>(null);
+  const [lastFormValues, setLastFormValues] = useState<Record<string, any> | null>(null);
   const [signalsInfoVisible, setSignalsInfoVisible] = useState(false);
   const [showPriceLine, setShowPriceLine] = useState(true);
   const [showBuySignals, setShowBuySignals] = useState(true);
   const [showSellSignals, setShowSellSignals] = useState(true);
   const [overviewExpanded, setOverviewExpanded] = useState(false);
+  const equityChartRef = useRef<ECharts | null>(null);
+  const drawdownChartRef = useRef<ECharts | null>(null);
+  const signalChartRef = useRef<ECharts | null>(null);
   const histogramChartRef = useRef<ECharts | null>(null);
 
-  const handleSubmit = async (payload: BacktestRequest) => {
+  const handleSubmit = async (payload: BacktestRequest, rawValues: any) => {
     try {
       setLoading(true);
+      equityChartRef.current = null;
+      drawdownChartRef.current = null;
+      signalChartRef.current = null;
+      histogramChartRef.current = null;
       const { data } = await api.post<BacktestResponse>("/run_backtest", payload);
       setResponse(data);
       setLastRunConfig(payload);
+      setLastFormValues(rawValues);
       message.success("Backtest complete");
     } catch (error: any) {
       const detail = error?.response?.data?.detail || error.message;
@@ -126,6 +136,204 @@ const App = () => {
       });
     });
     downloadCSV("indicator_statistics.csv", ["horizon", "metric", "value"], rows);
+  };
+
+  const handleDownloadReport = () => {
+    if (!response) {
+      message.warning("Run the backtest before downloading the report");
+      return;
+    }
+
+    const escapeHtml = (value: string) =>
+      value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+    const captureChart = (chart: ECharts | null) => {
+      if (!chart) return null;
+      try {
+        return chart.getDataURL({ type: "png", backgroundColor: "#ffffff" });
+      } catch (error) {
+        console.error("Failed to capture chart", error);
+        return null;
+      }
+    };
+
+    const selectionRows = lastFormValues ? buildSelectionRows(lastFormValues) : [];
+    const metricsRows = Object.entries(response.metrics);
+    const equityCurve = response.equity_curve;
+    const drawdownCurve = response.drawdown_curve;
+    const signalRows = (response.signals ?? []).map((s) => [
+      s.date,
+      s.type,
+      s.price ?? "",
+      s.size ?? "",
+      s.symbol ?? "",
+    ]);
+    const tradeRows = (response.trades ?? []).map((t) => [
+      t.symbol ?? "",
+      t.enter_date,
+      t.enter_price,
+      t.exit_date,
+      t.exit_price,
+      t.pnl,
+      t.ret,
+    ]);
+    const histogramRows = response.histogram
+      ? response.histogram.buckets.map((bucket) => [
+          bucket.bin_start,
+          bucket.bin_end,
+          bucket.count,
+        ])
+      : [];
+    const indicatorRows: Array<Array<string | number>> = [];
+    if (response.indicator_statistics) {
+      Object.entries(response.indicator_statistics).forEach(([horizon, metrics]) => {
+        Object.entries(metrics).forEach(([metric, value]) => {
+          indicatorRows.push([horizon, metric, value]);
+        });
+      });
+    }
+
+    const sectionTable = (rows: Array<Array<string | number>>, headers: string[]) => {
+      if (!rows.length) return "<p>No data available.</p>";
+      const headerCells = headers.map((h) => `<th>${escapeHtml(h)}</th>`).join("");
+      const bodyRows = rows
+        .map(
+          (row) =>
+            `<tr>${row
+              .map((cell) => `<td>${escapeHtml(String(cell ?? ""))}</td>`)
+              .join("")}</tr>`
+        )
+        .join("");
+      return `<table><thead><tr>${headerCells}</tr></thead><tbody>${bodyRows}</tbody></table>`;
+    };
+
+    const csvSection = (title: string, csv?: string | null) => {
+      if (!csv) return "";
+      return `
+        <details open>
+          <summary>${escapeHtml(title)}</summary>
+          <pre>${escapeHtml(csv)}</pre>
+        </details>
+      `;
+    };
+
+    const equityCsv = equityCurve?.dates.length
+      ? createCSVContent(
+          ["date", "value"],
+          equityCurve.dates.map((d, i) => [d, equityCurve.values[i]])
+        )
+      : null;
+    const drawdownCsv = drawdownCurve?.dates.length
+      ? createCSVContent(
+          ["date", "value"],
+          drawdownCurve.dates.map((d, i) => [d, drawdownCurve.values[i]])
+        )
+      : null;
+    const signalsCsv = createCSVContent(["date", "type", "price", "size", "symbol"], signalRows);
+    const tradesCsv = createCSVContent(
+      ["symbol", "enter_date", "enter_price", "exit_date", "exit_price", "pnl", "ret"],
+      tradeRows
+    );
+    const histogramCsv = histogramRows.length
+      ? createCSVContent(["bin_start", "bin_end", "count"], histogramRows)
+      : null;
+    const indicatorCsv = indicatorRows.length
+      ? createCSVContent(["horizon", "metric", "value"], indicatorRows)
+      : null;
+
+    const requestJson = lastRunConfig ? JSON.stringify(lastRunConfig, null, 2) : null;
+    const responseJson = JSON.stringify(response, null, 2);
+
+    const equityImage = captureChart(equityChartRef.current);
+    const drawdownImage = captureChart(drawdownChartRef.current);
+    const signalImage = captureChart(signalChartRef.current);
+    const histogramImage = captureChart(histogramChartRef.current);
+
+    const timestamp = new Date().toISOString();
+
+    const html = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Backtest Report</title>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 24px; color: #0f172a; }
+      h1 { margin-bottom: 4px; }
+      h2 { margin-top: 32px; }
+      table { border-collapse: collapse; width: 100%; margin-top: 12px; }
+      th, td { border: 1px solid #cbd5f5; padding: 8px; text-align: left; font-size: 13px; }
+      th { background: #eef2ff; }
+      pre { background: #f8fafc; padding: 12px; border-radius: 8px; overflow-x: auto; }
+      details { margin-top: 12px; }
+      img { max-width: 100%; height: auto; border: 1px solid #dbeafe; border-radius: 8px; margin-top: 12px; }
+      .charts { display: grid; gap: 24px; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
+    </style>
+  </head>
+  <body>
+    <h1>Backtest Report</h1>
+    <p>Generated at ${escapeHtml(timestamp)}</p>
+
+    <section>
+      <h2>Parameter Summary</h2>
+      ${selectionRows.length
+        ? sectionTable(selectionRows, ["Section", "Parameter", "Value"])
+        : "<p>No parameter selections recorded.</p>"}
+    </section>
+
+    <section>
+      <h2>Metrics</h2>
+      ${metricsRows.length
+        ? sectionTable(
+            metricsRows.map(([label, value]) => [label, value]),
+            ["Metric", "Value"]
+          )
+        : "<p>No metrics available.</p>"}
+    </section>
+
+    <section>
+      <h2>Charts</h2>
+      <div class="charts">
+        ${equityImage ? `<figure><img src="${equityImage}" alt="Equity Curve" /><figcaption>Equity Curve</figcaption></figure>` : ""}
+        ${drawdownImage ? `<figure><img src="${drawdownImage}" alt="Drawdown" /><figcaption>Drawdown</figcaption></figure>` : ""}
+        ${signalImage ? `<figure><img src="${signalImage}" alt="Signals" /><figcaption>Signals & Price</figcaption></figure>` : ""}
+        ${histogramImage ? `<figure><img src="${histogramImage}" alt="Histogram" /><figcaption>Return Distribution</figcaption></figure>` : ""}
+      </div>
+    </section>
+
+    <section>
+      <h2>Data Snapshots</h2>
+      ${csvSection("Equity Curve (CSV)", equityCsv)}
+      ${csvSection("Drawdown (CSV)", drawdownCsv)}
+      ${csvSection("Signals (CSV)", signalsCsv)}
+      ${csvSection("Trades (CSV)", tradesCsv)}
+      ${csvSection("Histogram (CSV)", histogramCsv)}
+      ${csvSection("Indicator Statistics (CSV)", indicatorCsv)}
+    </section>
+
+    <section>
+      <h2>Raw Payloads</h2>
+      ${requestJson
+        ? `<details open><summary>Request Parameters</summary><pre>${escapeHtml(requestJson)}</pre></details>`
+        : ""}
+      <details open>
+        <summary>Backtest Response</summary>
+        <pre>${escapeHtml(responseJson)}</pre>
+      </details>
+    </section>
+  </body>
+</html>`;
+
+    const blob = new Blob([html], { type: "text/html;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    const filename = `backtest-report-${new Date().toISOString().replace(/[:.]/g, "-")}.html`;
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    message.success("Report downloaded");
   };
 
   const histogramBins = response?.histogram?.bin_count ?? lastRunConfig?.hist_bins ?? null;
@@ -238,6 +446,9 @@ const App = () => {
                       <div className="card-header card-header--compact">
                         <Title level={4}>Backtest Overview</Title>
                         <Space size={8} wrap align="center">
+                          <Button size="small" type="primary" onClick={handleDownloadReport}>
+                            Download Report
+                          </Button>
                           <Button size="small" onClick={handleDownloadSummary}>
                             Download JSON
                           </Button>
@@ -336,7 +547,13 @@ const App = () => {
                           Download CSV
                         </Button>
                       </div>
-                      <EquityChart data={response.equity_curve} loading={loading} />
+                      <EquityChart
+                        data={response.equity_curve}
+                        loading={loading}
+                        onReady={(instance) => {
+                          equityChartRef.current = instance;
+                        }}
+                      />
                     </Card>
                     <Card className="result-card">
                       <div className="card-header">
@@ -345,7 +562,13 @@ const App = () => {
                           Download CSV
                         </Button>
                       </div>
-                      <DrawdownChart data={response.drawdown_curve} loading={loading} />
+                      <DrawdownChart
+                        data={response.drawdown_curve}
+                        loading={loading}
+                        onReady={(instance) => {
+                          drawdownChartRef.current = instance;
+                        }}
+                      />
                     </Card>
                   </div>
 
@@ -379,6 +602,9 @@ const App = () => {
                       showPrice={showPriceLine}
                       showBuys={showBuySignals}
                       showSells={showSellSignals}
+                      onReady={(instance) => {
+                        signalChartRef.current = instance;
+                      }}
                     />
                   </Card>
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -45,6 +45,28 @@ body {
   gap: 12px;
 }
 
+.sidebar-form .form-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.sidebar-form .form-row:last-child {
+  margin-bottom: 0;
+}
+
+.sidebar-form .form-row__item {
+  flex: 1 1 160px;
+  margin-bottom: 0;
+}
+
+.sidebar-form .form-row__item .ant-input-number,
+.sidebar-form .form-row__item .ant-select,
+.sidebar-form .form-row__item .ant-picker {
+  width: 100%;
+}
+
 .sidebar-form .ant-card {
   border-radius: 10px;
   box-shadow: 0 8px 20px rgba(46, 92, 255, 0.08);
@@ -279,8 +301,8 @@ body {
 
 .indicator-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
 }
 
 .indicator-grid__item {
@@ -290,17 +312,54 @@ body {
   padding: 12px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
 }
 
 .indicator-grid__item .ant-form-item {
   margin-bottom: 0;
 }
 
-.indicator-grid__item .ant-form-item + .ant-form-item,
-.indicator-grid__item .ant-form-item + .ant-space,
-.indicator-grid__item .ant-space + .ant-form-item {
-  margin-top: 12px;
+.indicator-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.indicator-header--with-toggle {
+  align-items: flex-start;
+}
+
+.indicator-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #475569;
+}
+
+.indicator-inline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.indicator-inline:last-child {
+  margin-bottom: 0;
+}
+
+.indicator-inline--align {
+  align-items: center;
+}
+
+.indicator-inline__item {
+  flex: 1 1 140px;
+  margin-bottom: 0 !important;
+}
+
+.indicator-inline--align .indicator-inline__item {
+  flex: 1 1 180px;
 }
 
 .info-pill {

--- a/frontend/src/utils/download.ts
+++ b/frontend/src/utils/download.ts
@@ -1,8 +1,4 @@
-export const downloadCSV = (
-  filename: string,
-  columns: string[],
-  rows: Array<Array<string | number>>
-) => {
+export const createCSVContent = (columns: string[], rows: Array<Array<string | number>>) => {
   const header = columns.join(",");
   const body = rows
     .map((row) =>
@@ -15,7 +11,15 @@ export const downloadCSV = (
         .join(",")
     )
     .join("\n");
-  const csv = `${header}\n${body}`;
+  return rows.length ? `${header}\n${body}` : `${header}\n`;
+};
+
+export const downloadCSV = (
+  filename: string,
+  columns: string[],
+  rows: Array<Array<string | number>>
+) => {
+  const csv = createCSVContent(columns, rows);
   const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");

--- a/frontend/src/utils/report.ts
+++ b/frontend/src/utils/report.ts
@@ -1,0 +1,85 @@
+import { Dayjs } from "dayjs";
+import { Filters } from "../types";
+
+type RawSelectionValues = Record<string, any>;
+
+type SelectionRow = [string, string, string | number];
+
+const formatValue = (value: unknown): string => {
+  if (value === undefined || value === null || value === "") return "—";
+  if (Array.isArray(value)) {
+    if (!value.length) return "—";
+    return value.join(", ");
+  }
+  return String(value);
+};
+
+const formatDate = (value?: Dayjs) => (value ? value.format("YYYY-MM-DD") : "—");
+const formatBool = (value?: boolean) => (value ? "Enabled" : "Disabled");
+
+export const buildSelectionRows = (values: RawSelectionValues): SelectionRow[] => {
+  const rows: SelectionRow[] = [];
+  const [start, end] = (values.date ?? []) as [Dayjs | undefined, Dayjs | undefined];
+  const filtersValues = (values.filters ?? {}) as Filters & { exclude_tickers?: string[] };
+
+  const addRow = (section: string, label: string, value: unknown) => {
+    rows.push([section, label, formatValue(value)]);
+  };
+
+  addRow("Strategy", "Strategy", values.strategy);
+  addRow("Strategy", "Start date", formatDate(start));
+  addRow("Strategy", "End date", formatDate(end));
+  addRow("Strategy", "Initial capital", values.capital);
+  addRow("Strategy", "Fee (bps)", values.fee_bps);
+  addRow("Strategy", "Hold days", values.hold_days);
+  addRow("Strategy", "Stop loss (%)", values.stop_loss_pct);
+  addRow("Strategy", "Take profit (%)", values.take_profit_pct);
+
+  addRow("Universe Filters", "Sectors", filtersValues.sectors ?? []);
+  addRow("Universe Filters", "Market cap min", filtersValues.mcap_min);
+  addRow("Universe Filters", "Market cap max", filtersValues.mcap_max);
+  addRow("Universe Filters", "Exclude tickers", filtersValues.exclude_tickers ?? []);
+
+  addRow("RSI", "Enabled", formatBool(values.enable_rsi));
+  addRow("RSI", "Lookback", values.rsi_n);
+  addRow("RSI", "Mode", values.rsi_rule?.mode);
+  addRow("RSI", "Threshold", values.rsi_rule?.threshold);
+
+  addRow("MACD", "Enabled", formatBool(values.use_macd));
+  addRow("MACD", "Fast", values.macd_fast);
+  addRow("MACD", "Slow", values.macd_slow);
+  addRow("MACD", "Signal", values.macd_signal);
+  addRow("MACD", "Rule", values.macd_rule);
+
+  addRow("OBV", "Enabled", formatBool(values.use_obv));
+  addRow("OBV", "Rule", values.obv_rule);
+
+  addRow("EMA", "Enabled", formatBool(values.use_ema));
+  addRow("EMA", "Short", values.ema_short);
+  addRow("EMA", "Long", values.ema_long);
+
+  addRow("ADX", "Enabled", formatBool(values.use_adx));
+  addRow("ADX", "Lookback", values.adx_n);
+  addRow("ADX", "Min ADX", values.adx_min);
+
+  addRow("Aroon", "Enabled", formatBool(values.use_aroon));
+  addRow("Aroon", "Lookback", values.aroon_n);
+  addRow("Aroon", "Aroon up", values.aroon_up);
+  addRow("Aroon", "Aroon down", values.aroon_down);
+
+  addRow("Stochastic", "Enabled", formatBool(values.use_stoch));
+  addRow("Stochastic", "%K", values.stoch_k);
+  addRow("Stochastic", "%D", values.stoch_d);
+  addRow("Stochastic", "Threshold", values.stoch_threshold);
+  addRow("Stochastic", "Rule", values.stoch_rule);
+
+  addRow("Signal Rules", "Policy", values.policy);
+  addRow("Signal Rules", "k", values.policy === "atleast_k" ? values.k : "—");
+  addRow("Signal Rules", "Max horizon", values.max_horizon);
+  addRow("Signal Rules", "Histogram horizon", values.hist_horizon);
+  addRow("Signal Rules", "Histogram bins", values.hist_bins);
+
+  return rows;
+};
+
+export default buildSelectionRows;


### PR DESCRIPTION
## Summary
- tighten the strategy form and indicator cards so inputs share rows and toggles sit beside titles
- add an HTML backtest report export that captures parameters, metrics, chart images, and CSV snapshots
- share selection formatting logic and CSV builders for reuse between the sidebar export and report generation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68df9173e1c0832b9b14364d2fd17935