### PR TITLE
Refine indicator sidebar layout

### DIFF
--- a/frontend/src/components/SidebarForm.tsx
+++ b/frontend/src/components/SidebarForm.tsx
@@ -542,12 +542,12 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
   const infoTitles: Record<InfoModalKey, string> = {
     strategy: "Strategy Settings",
     execution: "Execution Settings",
-    rsi: "RSI",
-    macd: "MACD",
-    obv: "On-Balance Volume",
-    ema: "EMA Cross",
-    adx: "Average Directional Index",
-    aroon: "Aroon",
+    rsi: "Relative Strength Index (RSI)",
+    macd: "Moving Average Convergence Divergence (MACD)",
+    obv: "On-Balance Volume (OBV)",
+    ema: "Exponential Moving Average Cross (EMA)",
+    adx: "Average Directional Index (ADX)",
+    aroon: "Aroon Oscillator",
     stoch: "Stochastic Oscillator",
     signals: "Signal Rules",
     universe: "Universe Filters",
@@ -663,19 +663,21 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
         <Card title="Indicators" size="small" bordered={false} className="sidebar-card sidebar-card--indicators">
           <div className="indicator-grid">
             <div className="indicator-grid__item">
-              <div className="indicator-header">
-                <Text strong>Relative Strength Index (RSI)</Text>
-                <Button type="text" size="small" onClick={() => openInfo("rsi")}>
-                  Describe
-                </Button>
+              <div className="indicator-header indicator-header--with-toggle">
+                <Text strong>RSI</Text>
+                <Space size={6} align="center">
+                  <div className="indicator-toggle">
+                    <span>Enabled</span>
+                    <Form.Item name="enable_rsi" valuePropName="checked" noStyle>
+                      <Switch size="small" />
+                    </Form.Item>
+                  </div>
+                  <Button type="text" size="small" onClick={() => openInfo("rsi")}>
+                    Describe
+                  </Button>
+                </Space>
               </div>
-              <div className="indicator-inline indicator-inline--align">
-                <div className="indicator-toggle">
-                  <span>Enabled</span>
-                  <Form.Item name="enable_rsi" valuePropName="checked" noStyle>
-                    <Switch size="small" />
-                  </Form.Item>
-                </div>
+              <div className="indicator-inline">
                 <Form.Item
                   label="Mode"
                   name={["rsi_rule", "mode"]}
@@ -690,41 +692,53 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
                     disabled={!enableRsi}
                   />
                 </Form.Item>
-              </div>
-              <div className="indicator-inline">
                 <Form.Item
-                  label="RSI Lookback"
+                  label="Lookback"
                   name="rsi_n"
                   className="indicator-inline__item"
                   style={{ marginBottom: 0 }}
                 >
-                  <InputNumber min={2} max={100} style={{ width: "100%" }} disabled={!enableRsi} />
+                  <InputNumber
+                    min={2}
+                    max={100}
+                    style={{ width: "100%" }}
+                    disabled={!enableRsi}
+                    controls={false}
+                  />
                 </Form.Item>
                 <Form.Item
-                  label="RSI Threshold"
+                  label="Threshold"
                   name={["rsi_rule", "threshold"]}
                   className="indicator-inline__item"
                   style={{ marginBottom: 0 }}
                 >
-                  <InputNumber min={0} max={100} style={{ width: "100%" }} disabled={!enableRsi} />
+                  <InputNumber
+                    min={0}
+                    max={100}
+                    style={{ width: "100%" }}
+                    disabled={!enableRsi}
+                    controls={false}
+                  />
                 </Form.Item>
               </div>
             </div>
 
             <div className="indicator-grid__item">
-              <div className="indicator-header">
-                <Text strong>Moving Average Convergence Divergence (MACD)</Text>
-                <Button type="text" size="small" onClick={() => openInfo("macd")}>
-                  Describe
-                </Button>
+              <div className="indicator-header indicator-header--with-toggle">
+                <Text strong>MACD</Text>
+                <Space size={6} align="center">
+                  <div className="indicator-toggle">
+                    <span>Enabled</span>
+                    <Form.Item name="use_macd" valuePropName="checked" noStyle>
+                      <Switch size="small" />
+                    </Form.Item>
+                  </div>
+                  <Button type="text" size="small" onClick={() => openInfo("macd")}>
+                    Describe
+                  </Button>
+                </Space>
               </div>
-              <div className="indicator-inline indicator-inline--align">
-                <div className="indicator-toggle">
-                  <span>Enabled</span>
-                  <Form.Item name="use_macd" valuePropName="checked" noStyle>
-                    <Switch size="small" />
-                  </Form.Item>
-                </div>
+              <div className="indicator-inline">
                 <Form.Item
                   label="Rule"
                   name="macd_rule"
@@ -739,8 +753,6 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
                     disabled={!useMacd}
                   />
                 </Form.Item>
-              </div>
-              <div className="indicator-inline">
                 <Form.Item
                   label="Fast"
                   name="macd_fast"
@@ -769,19 +781,21 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
             </div>
 
             <div className="indicator-grid__item">
-              <div className="indicator-header">
-                <Text strong>On-Balance Volume (OBV)</Text>
-                <Button type="text" size="small" onClick={() => openInfo("obv")}>
-                  Describe
-                </Button>
+              <div className="indicator-header indicator-header--with-toggle">
+                <Text strong>OBV</Text>
+                <Space size={6} align="center">
+                  <div className="indicator-toggle">
+                    <span>Enabled</span>
+                    <Form.Item name="use_obv" valuePropName="checked" noStyle>
+                      <Switch size="small" />
+                    </Form.Item>
+                  </div>
+                  <Button type="text" size="small" onClick={() => openInfo("obv")}>
+                    Describe
+                  </Button>
+                </Space>
               </div>
-              <div className="indicator-inline indicator-inline--align">
-                <div className="indicator-toggle">
-                  <span>Enabled</span>
-                  <Form.Item name="use_obv" valuePropName="checked" noStyle>
-                    <Switch size="small" />
-                  </Form.Item>
-                </div>
+              <div className="indicator-inline">
                 <Form.Item
                   label="Rule"
                   name="obv_rule"
@@ -801,7 +815,7 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
 
             <div className="indicator-grid__item">
               <div className="indicator-header indicator-header--with-toggle">
-                <Text strong>Exponential Moving Average Cross (EMA)</Text>
+                <Text strong>EMA</Text>
                 <Space size={6} align="center">
                   <div className="indicator-toggle">
                     <span>Enabled</span>
@@ -836,7 +850,7 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
 
             <div className="indicator-grid__item">
               <div className="indicator-header indicator-header--with-toggle">
-                <Text strong>Average Directional Index (ADX)</Text>
+                <Text strong>ADX</Text>
                 <Space size={6} align="center">
                   <div className="indicator-toggle">
                     <span>Enabled</span>
@@ -871,7 +885,7 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
 
             <div className="indicator-grid__item">
               <div className="indicator-header indicator-header--with-toggle">
-                <Text strong>Aroon Oscillator</Text>
+                <Text strong>Aroon</Text>
                 <Space size={6} align="center">
                   <div className="indicator-toggle">
                     <span>Enabled</span>
@@ -914,7 +928,7 @@ const SidebarForm = ({ loading, onSubmit }: SidebarFormProps) => {
 
             <div className="indicator-grid__item">
               <div className="indicator-header indicator-header--with-toggle">
-                <Text strong>Stochastic Oscillator</Text>
+                <Text strong>Stoch</Text>
                 <Space size={6} align="center">
                   <div className="indicator-toggle">
                     <span>Enabled</span>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -32,24 +32,24 @@ body {
   width: 100%;
   height: 100%;
   overflow-y: auto;
-  padding: 12px;
+  padding: 8px;
   box-sizing: border-box;
 }
 
 .sidebar-form {
   height: 100%;
   overflow-y: auto;
-  padding: 4px 8px 16px;
+  padding: 0 8px 12px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
 }
 
 .sidebar-form .form-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
-  margin-bottom: 12px;
+  gap: 8px;
+  margin-bottom: 8px;
 }
 
 .sidebar-form .form-row:last-child {
@@ -69,25 +69,25 @@ body {
 
 .sidebar-form .ant-card {
   border-radius: 10px;
-  box-shadow: 0 8px 20px rgba(46, 92, 255, 0.08);
+  box-shadow: 0 6px 16px rgba(46, 92, 255, 0.08);
 }
 
 .sidebar-form .ant-card-head {
   min-height: 34px;
-  padding: 0 12px;
+  padding: 0 10px;
 }
 
 .sidebar-form .ant-card-head-title {
-  padding: 6px 0;
-  font-size: 14px;
+  padding: 4px 0;
+  font-size: 13px;
 }
 
 .sidebar-form .ant-card-body {
-  padding: 12px;
+  padding: 10px;
 }
 
 .sidebar-form .ant-form-item {
-  margin-bottom: 12px;
+  margin-bottom: 8px;
 }
 
 .sidebar-form .ant-form-item-label > label {
@@ -301,15 +301,15 @@ body {
 
 .indicator-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 8px;
 }
 
 .indicator-grid__item {
   background: #f9faff;
   border: 1px solid #e2e7ff;
-  border-radius: 12px;
-  padding: 12px;
+  border-radius: 10px;
+  padding: 10px;
   display: flex;
   flex-direction: column;
 }
@@ -322,27 +322,27 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  margin-bottom: 8px;
+  gap: 6px;
+  margin-bottom: 6px;
 }
 
 .indicator-header--with-toggle {
-  align-items: flex-start;
+  align-items: center;
 }
 
 .indicator-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  font-size: 12px;
+  gap: 4px;
+  font-size: 11px;
   color: #475569;
 }
 
 .indicator-inline {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
-  margin-bottom: 12px;
+  gap: 8px;
+  margin-bottom: 8px;
 }
 
 .indicator-inline:last-child {


### PR DESCRIPTION
## Summary
- abbreviate indicator headers and surface full names in the describe modal
- compact the RSI controls and reposition toggles to reduce wasted space
- tighten sidebar spacing to let more indicators appear without scrolling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dfc9d2ad68832b84e5278d5dd8d800