### PR TITLE
Fix ADX backtest calculation error

### DIFF
--- a/backend/backtest_system.py
+++ b/backend/backtest_system.py
@@ -347,8 +347,8 @@ def calculate_adx(
     tr = pd.concat([tr1, tr2, tr3], axis=1).max(axis=1)
 
     atr = tr.rolling(window=n, min_periods=n).mean()
-    plus_di = 100.0 * (pd.Series(plus_dm).rolling(window=n, min_periods=n).sum() / atr)
-    minus_di = 100.0 * (pd.Series(minus_dm).rolling(window=n, min_periods=n).sum() / atr)
+    plus_di = 100.0 * (pd.Series(plus_dm, index=high.index).rolling(window=n, min_periods=n).sum() / atr)
+    minus_di = 100.0 * (pd.Series(minus_dm, index=high.index).rolling(window=n, min_periods=n).sum() / atr)
     dx = (abs(plus_di - minus_di) / (plus_di + minus_di)) * 100.0
     adx = dx.rolling(window=n, min_periods=n).mean()
     signal = adx >= min_adx


### PR DESCRIPTION
When input Series have DatetimeIndex, np.where() returns numpy arrays that lose the index. Creating new Series from these arrays without specifying index caused misalignment with atr (which has DatetimeIndex), resulting in all NaN ADX values and empty backtest results.

Fix: Preserve original index when creating plus_di and minus_di Series.